### PR TITLE
ping go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 sudo: required
 language: go
 go:
-- "1.11"
+- "1.11.2"
 services:
 - docker
 notifications:

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ subprojects {
 
 golang {
   packagePath = 'github.com/apache/incubator-openwhisk-runtime-go'
+  goVersion = '1.11.2'
 }
 
 

--- a/golang1.11/Dockerfile
+++ b/golang1.11/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.0
+FROM golang:1.11.2
 RUN apt-get update && apt-get install -y \
     curl \
     jq \


### PR DESCRIPTION
This allows:
- more stable upgrades/bumps
- In CICD pipelines where there is a different version of go installed, the gradle config will use the correct one when running the tests
