### PR TITLE
Adjust build to be kinder to multi-architecture.

### DIFF
--- a/actionProxyLoop/build.gradle
+++ b/actionProxyLoop/build.gradle
@@ -17,3 +17,5 @@
 
 ext.dockerImageName = 'actionloop'
 apply from: '../gradle/docker.gradle'
+
+distDocker.dependsOn ':goBuild'

--- a/build.gradle
+++ b/build.gradle
@@ -43,13 +43,63 @@ subprojects {
 
 golang {
   packagePath = 'github.com/apache/incubator-openwhisk-runtime-go'
-  goVersion = '1.11.3'
+  goVersion = '1.11.4'
 }
 
+/*
+    The OpenWhiskPlatform class is a utility class to make the rest of what
+    happens with platforms a bit more understandable.  A "Platform" is a tuple
+    of an operating system and a processor.  Currently, the OpenWhisk CLI
+    supports three OS's:  Linux, Mac/Darwin, and Windows.  It supports x86
+    (32-bit or 64-bit) on all OS's.  On Linux, it also support System Z (s390x),
+    PowerPC (ppc64le), and ARM (32-bit and 64-bit) architectures.
+    Different contexts use different codings to refer to these architectures --
+    the class attempts to provide and interpret all needed codings.  Internal
+    storage is in "GO" format:
+        OS: linux, darwin, windows
+        Arch: 386, amd64, s390x, ppc64le, arm64
+ */
+class OpenWhiskPlatform {
+    String goOs
+    String goArch
 
-build.dependsOn vendor
+    /*
+        Create a platform for the local platform
+     */
+    OpenWhiskPlatform() {
+        this(System.properties['os.name'], System.properties['os.arch'])
+    }
 
-build {
-  targetPlatform = ['linux-amd64']
-  go 'build -o actionProxyLoop/proxy main/proxy.go'
+    OpenWhiskPlatform(String platformSpec) {
+        this(*platformSpec.split('-'))
+    }
+
+    OpenWhiskPlatform(String inOs, String inArch) {
+        goOs=inOs.toLowerCase()
+                 .replaceAll(~/^mac.*$/,'darwin')
+                 .replaceAll(~/^.*n[ui]x.*$/,'linux')
+        goArch=inArch.toLowerCase()
+                     .replaceAll('x86_64','amd64')
+                     .replaceAll('i386','386')
+                     .replaceAll('x86_32','386')
+                     .replaceAll('aarch64','arm64')
+    }
+
+    /**
+     * Return the Openwhisk OS for this Platform
+     */
+    String getOwOs() {
+        ((goOs == 'darwin') ? 'mac' : goOs)
+    }
+
+    String getGoPlatform() {
+        "${goOs}-${goArch}"
+    }
+}
+
+goBuild.dependsOn goVendor
+
+goBuild {
+   targetPlatform = ["linux-${(new OpenWhiskPlatform()).goArch}".toString()]
+   go 'build -o actionProxyLoop/proxy main/proxy.go'
 }

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 -->
-#  Developers Guide for Runtime itself
+# Developers Guide for Runtime itself
 
 <a name="building"/>
 
@@ -26,16 +26,16 @@ You need a Linux or an OSX environment, with Java and Docker installed to build 
 
 Prerequisites for running build and tests with gradle:
 
-- docker
-- jdk
+-   docker
+-   jdk
 
-To compile go proxy *in amd64 architecture* for docker:
+To compile go proxy *in your local architecture* for docker:
 
 ```
-./gradlew build
+./gradlew goBuild
 ```
 
-To build the docker images, after compiling go proxy:
+To build the docker images (this will also compile the go proxy):
 
 ```
 ./gradlew distDocker
@@ -43,8 +43,8 @@ To build the docker images, after compiling go proxy:
 
 This will build the images:
 
-* `actionloop-golang-v1.11`: an image supporting  Go sources
-* `actionloop`: the base image, supporting generic executables ans shell script
+*   `actionloop-golang-v1.11`: an image supporting  Go sources
+*   `actionloop`: the base image, supporting generic executables and shell script
 
 The `actionloop` image can be used for supporting other compiled programming languages as long as they implement a `compile` script and the *action loop* protocol described below.
 
@@ -59,13 +59,13 @@ To run tests:
 
 If you want to develop the proxy and run tests natively, you can do it on Linux or OSX. Development has been tested on Ubuntu Linux (14.04) and OSX 10.13. Probably other distributions work, maybe even Windows with WSL, but since it is not tested YMMMV.
 
-You need to install, of course [go 1.11.0](https://golang.org/doc/install)
+You need to install, of course [go 1.11.x](https://golang.org/doc/install)
 
 Then you need a set of utilities used in tests:
 
-- bc
-- zip
-- realpath
+-   bc
+-   zip
+-   realpath
 
 Linux: `apt-get install bc zip realpath`
 OSX: `brew install zip coreutils`

--- a/golang1.11/build.gradle
+++ b/golang1.11/build.gradle
@@ -23,8 +23,7 @@ distDocker.dependsOn 'copyCompiler'
 distDocker.dependsOn 'copyEpilogue'
 distDocker.finalizedBy('cleanup')
 
-
-task copyProxy(type: Copy) {
+task copyProxy(type: Copy, dependsOn: ':goBuild') {
     from '../actionProxyLoop/proxy'
     into '.'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Dgogradle.alias=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 org.gradle.jvmargs=-Dgogradle.alias=true


### PR DESCRIPTION
1.  Add code to build.gradle (stolen^H^H^H^H^H^Hborrowed from the CLI build)
    to determine the building processor architecture and target
    'linux-FOO' for that architecture.
2.  Set the gogradle flag to prefix gogradle stages with 'go' (eg
    goBuild), hence avoiding confusion with gradle build-in steps and
    unwilling execution of 'test', etc.
3.  Add a dependency on ':goBuild' to the 'distDocker' builds to ensure
    that the proxy is properly build before building the Docker images.
4.  Bump the Go version used by gogradle for the proxy build to 1.11.4
    to match the version used in the docker images.  We could make this
    a build argument to avoid having it in multiple places.
5.  Documentation updates, including linting.