### PR TITLE
update go from 1.11.4 to 1.11.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 sudo: required
 language: go
 go:
-- "1.11.3"
+- "1.11.5"
 services:
 - docker
 notifications:

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ subprojects {
 
 golang {
   packagePath = 'github.com/apache/incubator-openwhisk-runtime-go'
-  goVersion = '1.11.3'
+  goVersion = '1.11.5'
 }
 
 

--- a/golang1.11/CHANGELOG.md
+++ b/golang1.11/CHANGELOG.md
@@ -21,4 +21,4 @@
 
 ## Apache 1.13.0-incubating (next release)
 - Initial version
-- Go 1.11.4
+- Go 1.11.5


### PR DESCRIPTION
go1.11.5 (released 2019/01/23) includes a security fix to the crypto/elliptic package. See the [Go 1.11.5 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.11.5+label%3ACherryPickApproved) on our issue tracker for details.
