### PR TITLE
add support for confluent-go-kafka library

### DIFF
--- a/golang1.11/Dockerfile
+++ b/golang1.11/Dockerfile
@@ -1,10 +1,17 @@
 FROM golang:1.11.4
-RUN apt-get update && apt-get install -y \
-    curl \
-    jq \
-    git \
-    realpath \
-    && rm -rf /var/lib/apt/lists/*
+RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" \
+     >>/etc/apt/sources.list &&\
+    apt-get update && apt-get install -y \
+     curl \
+     jq \
+     git \
+     realpath &&\
+    apt-get -y install \
+     librdkafka1=0.11.6-1~bpo9+1 \
+     librdkafka++1=0.11.6-1~bpo9+1 && \
+    apt-get -y install \
+     librdkafka-dev=0.11.6-1~bpo9+1 && \
+    rm -rf /var/lib/apt/lists/*
 RUN mkdir /action
 WORKDIR /action
 ADD proxy /bin/proxy


### PR DESCRIPTION
The main library for using Kafka in go is confluentinc/confluent-go-kafka
Unfortuanately it is based on the C library librdkafka
This patch installs librdkafka in the Go image to support it
