### PR TITLE
Will our heroes be able to build a static go executable with travis?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ deploy:
       repo: apache/incubator-openwhisk-runtime-go
   - provider: script
     skip_cleanup: true
-    script: "./tools/travis/publish.sh openwhisk actionloop-v2 latest"
+    script: "./tools/travis/publish.sh openwhisk actionloop latest"
     on:
       branch: master
       repo: apache/incubator-openwhisk-runtime-go

--- a/actionloop/build.gradle
+++ b/actionloop/build.gradle
@@ -23,9 +23,9 @@ distDocker.finalizedBy('cleanup')
 
 task staticBuildProxy(type: Exec) {
 	environment CGO_ENABLED: "0"
-	commandLine 'go', 'build', 
-		'-o',  'proxy', '-a', 
-		'-ldflags', '-extldflags "-static"', 
+	commandLine 'go', 'build',
+		'-o',  'proxy', '-a',
+		'-ldflags', '-extldflags "-static"',
 		'../main/proxy.go'
 }
 

--- a/actionloop/build.gradle
+++ b/actionloop/build.gradle
@@ -18,12 +18,15 @@
 ext.dockerImageName = 'actionloop-v2'
 apply from: '../gradle/docker.gradle'
 
-distDocker.dependsOn 'copyProxy'
+distDocker.dependsOn 'staticBuildProxy'
 distDocker.finalizedBy('cleanup')
 
-task copyProxy(type: Copy) {
-    from '../common/proxy'
-    into '.'
+task staticBuildProxy(type: Exec) {
+	environment CGO_ENABLED: "0"
+	commandLine 'go', 'build', 
+		'-o',  'proxy', '-a', 
+		'-ldflags', '-extldflags "-static"', 
+		'../main/proxy.go'
 }
 
 task cleanup(type: Delete) {


### PR DESCRIPTION
Since everything else fails, now the build for the docker containers for actionloop builds with the go command the static executables with a dirty "go build" call instead of relying on the badly broken go Gradle plugin that insists building a dynamic one in Travis even if it works correctly on OSX.

Will it work? Will I ever be able to use actionloop with Alpine based images that does not have the glibc in it?
