### PR TITLE
Go12 jar support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ vendor/
 common/proxy
 actionloop/proxy
 golang1.11/proxy
+golang1.12/proxy
 
 # Go test transient files
 openwhisk/_test/exec
@@ -22,6 +23,7 @@ openwhisk/_test/hi
 openwhisk/_test/hello_greeting
 openwhisk/_test/hello_message
 openwhisk/_test/*.zip
+openwhisk/_test/*.jar
 openwhisk/_test/compile/
 openwhisk/_test/output/
 openwhisk/action/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,3 +34,5 @@ ActionLoop for Scripting Languages
 - Support for Go 1.12.4
 - Support for jar not expanded for Java when set OW_SAVE_JAR
 - You can initalize multiple times when debugging
+- Removed gogradle plugin, now building directly with go
+

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,3 +31,6 @@ ActionLoop for Scripting Languages
 - any script starting with '#!' is recognized as executable
 - now the -compile will zip the entire directory of the `bin` directory after compilation
 - if you upload a folder `src/exec` the entire directory is moved to `bin`, including other uploaded files
+- Support for Go 1.12.4
+- Support for jar not expanded for Java when set OW_SAVE_JAR
+- You can initalize multiple times when debugging

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ subprojects {
     scalafmt.configFilePath = gradle.scalafmt.config
 }
 
+// used only to build go 1.11 - go 1.12 build with go modules and native go
 golang {
   packagePath = 'github.com/apache/incubator-openwhisk-runtime-go'
   goVersion = '1.11.6'

--- a/build.gradle
+++ b/build.gradle
@@ -24,36 +24,8 @@ buildscript {
     }
 }
 
-plugins {
-    id 'com.github.blindpirate.gogradle' version '0.8.1'
-}
-
-dependencies {
-    golang {
-        build 'github.com/sirupsen/logrus@v1.1.0'
-        test 'github.com/stretchr/testify@v1.2.1'
-    }
-}
-
-
 subprojects {
     apply plugin: 'scalafmt'
     scalafmt.configFilePath = gradle.scalafmt.config
 }
 
-// used only to build go 1.11 - go 1.12 build with go modules and native go
-golang {
-  packagePath = 'github.com/apache/incubator-openwhisk-runtime-go'
-  goVersion = '1.11.6'
-}
-
-build.dependsOn vendor
-
-build {
-  targetPlatform = ['linux-amd64']
-  go """build -o common/proxy -ldflags '-extldflags "-static"'  main/proxy.go"""
-}
-
-task cleanup(type: Delete) {
-    delete 'common/proxy'
-}

--- a/common/gobuild.py
+++ b/common/gobuild.py
@@ -55,7 +55,8 @@ def build(parent, source_dir, target):
     # compile...
     env = {
       "PATH": os.environ["PATH"],
-      "GOPATH": os.path.abspath(parent)
+      "GOPATH": os.path.abspath(parent),
+      "GOCACHE": "/tmp"
     }
     if os.path.isdir("%s/main" % source_dir):
         source_dir += "/main"

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/apache/incubator-openwhisk-runtime-go
+
+go 1.12
+
+require github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/golang1.11/build.gradle
+++ b/golang1.11/build.gradle
@@ -18,14 +18,20 @@
 ext.dockerImageName = 'actionloop-golang-v1.11'
 apply from: '../gradle/docker.gradle'
 
-distDocker.dependsOn 'copyProxy'
+distDocker.dependsOn 'staticBuildProxy'
 distDocker.dependsOn 'copyCompiler'
 distDocker.dependsOn 'copyEpilogue'
 distDocker.finalizedBy('cleanup')
 
-task copyProxy(type: Copy) {
-    from '../common/proxy'
-    into '.'
+task staticBuildProxy(type: Exec) {
+	environment CGO_ENABLED: "0"
+	environment GOOS: "linux"
+	environment GOARCH: "amd64"
+
+	commandLine 'go', 'build',
+		'-o',  'proxy', '-a',
+		'-ldflags', '-extldflags "-static"',
+		'../main/proxy.go'
 }
 
 task copyCompiler(type: Copy) {

--- a/golang1.12/Dockerfile
+++ b/golang1.12/Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.12.4
+RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" \
+     >>/etc/apt/sources.list &&\
+    apt-get update && apt-get install -y \
+     curl \
+     jq \
+     git \
+     realpath &&\
+    apt-get -y install \
+     librdkafka1=0.11.6-1~bpo9+1 \
+     librdkafka++1=0.11.6-1~bpo9+1 && \
+    apt-get -y install \
+     librdkafka-dev=0.11.6-1~bpo9+1 && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir /action
+WORKDIR /action
+ADD proxy /bin/proxy
+ADD gobuild.py /bin/compile
+ADD gobuild.py.launcher.go /bin/compile.launcher.go
+ENV OW_COMPILER=/bin/compile
+ENTRYPOINT [ "/bin/proxy" ]

--- a/golang1.12/build.gradle
+++ b/golang1.12/build.gradle
@@ -18,15 +18,22 @@
 ext.dockerImageName = 'actionloop-golang-v1.12'
 apply from: '../gradle/docker.gradle'
 
-distDocker.dependsOn 'copyProxy'
+distDocker.dependsOn 'staticBuildProxy'
 distDocker.dependsOn 'copyCompiler'
 distDocker.dependsOn 'copyEpilogue'
 distDocker.finalizedBy('cleanup')
 
-task copyProxy(type: Copy) {
-    from '../common/proxy'
-    into '.'
+task staticBuildProxy(type: Exec) {
+	environment CGO_ENABLED: "0"
+	environment GOOS: "linux"
+	environment GOARCH: "amd64"
+
+	commandLine 'go', 'build',
+		'-o',  'proxy', '-a',
+		'-ldflags', '-extldflags "-static"',
+		'../main/proxy.go'
 }
+
 
 task copyCompiler(type: Copy) {
     from '../common/gobuild.py'

--- a/golang1.12/build.gradle
+++ b/golang1.12/build.gradle
@@ -15,21 +15,27 @@
  * limitations under the License.
  */
 
-ext.dockerImageName = 'actionloop-v2'
+ext.dockerImageName = 'actionloop-golang-v1.12'
 apply from: '../gradle/docker.gradle'
 
-distDocker.dependsOn 'staticBuildProxy'
+distDocker.dependsOn 'copyProxy'
+distDocker.dependsOn 'copyCompiler'
+distDocker.dependsOn 'copyEpilogue'
 distDocker.finalizedBy('cleanup')
 
-task staticBuildProxy(type: Exec) {
-	environment CGO_ENABLED: "0"
-	environment GOOS: "linux"
-	environment GOARCH: "amd64"
+task copyProxy(type: Copy) {
+    from '../common/proxy'
+    into '.'
+}
 
-	commandLine 'go', 'build',
-		'-o',  'proxy', '-a',
-		'-ldflags', '-extldflags "-static"',
-		'../main/proxy.go'
+task copyCompiler(type: Copy) {
+    from '../common/gobuild.py'
+    into '.'
+}
+
+task copyEpilogue(type: Copy) {
+    from '../common/gobuild.py.launcher.go'
+    into '.'
 }
 
 task cleanup(type: Delete) {

--- a/openwhisk/_test/build.sh
+++ b/openwhisk/_test/build.sh
@@ -54,3 +54,6 @@ cd ..
 build exec
 test -e exec.zip && rm exec.zip
 zip -q -r exec.zip exec etc dir
+test -e sample.jar && rm sample.jar
+cd jar ; zip -q -r ../sample.jar * ; cd ..
+

--- a/openwhisk/_test/build.sh
+++ b/openwhisk/_test/build.sh
@@ -51,9 +51,10 @@ cd src
 zip -q -r ../hello.zip main.go hello
 cd ..
 
+test -e sample.jar && rm sample.jar
+cd jar ; zip -q -r ../sample.jar * ; cd ..
+
 build exec
 test -e exec.zip && rm exec.zip
 zip -q -r exec.zip exec etc dir
-test -e sample.jar && rm sample.jar
-cd jar ; zip -q -r ../sample.jar * ; cd ..
 

--- a/openwhisk/_test/jar/META-INF/MANIFEST.MF
+++ b/openwhisk/_test/jar/META-INF/MANIFEST.MF
@@ -1,0 +1,4 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+Manifest-Version: 1.0
+Created-By: 1.8.0_191 (Oracle Corporation)

--- a/openwhisk/_test/jar/hello.txt
+++ b/openwhisk/_test/jar/hello.txt
@@ -1,0 +1,2 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.

--- a/openwhisk/compiler.go
+++ b/openwhisk/compiler.go
@@ -27,6 +27,7 @@ import (
 
 // check if the file exists and it is already compiled
 func isCompiled(file string) bool {
+	Debug("IsCompiled? %s", file)
 	_, err := os.Stat(file)
 	if err != nil {
 		return false

--- a/openwhisk/extractor.go
+++ b/openwhisk/extractor.go
@@ -56,6 +56,12 @@ func (ap *ActionProxy) ExtractAction(buf *[]byte, suffix string) (string, error)
 	os.MkdirAll(newDir, 0755)
 	file := newDir + "/exec"
 	if IsZip(*buf) {
+		jar := os.Getenv("OW_SAVE_JAR")
+		if jar != "" {
+			jarFile := newDir + "/" + jar
+			Debug("Extract Action, checking if it is a jar first")
+			return jarFile, UnzipOrSaveJar(*buf, newDir, jarFile)
+		}
 		Debug("Extract Action, assuming a zip")
 		return file, Unzip(*buf, newDir)
 	}

--- a/openwhisk/extractor_test.go
+++ b/openwhisk/extractor_test.go
@@ -60,12 +60,37 @@ func TestExtractActionTest_zip(t *testing.T) {
 
 func TestExtractAction_script(t *testing.T) {
 	log, _ := ioutil.TempFile("", "log")
+	assert.Nil(t, os.RemoveAll("./action/x4"))
 	ap := NewActionProxy("./action/x4", "", log, log)
 	buf := []byte("#!/bin/sh\necho ok")
 	_, err := ap.ExtractAction(&buf, "bin")
 	//fmt.Print(err)
 	assert.Nil(t, err)
 }
+
+func TestExtractAction_save_jar(t *testing.T) {
+	os.Setenv("OW_SAVE_JAR", "exec.jar")
+	log, _ := ioutil.TempFile("", "log")
+	assert.Nil(t, os.RemoveAll("./action/x5"))
+	ap := NewActionProxy("./action/x5", "", log, log)
+	file, _ := ioutil.ReadFile("_test/sample.jar")
+	_, err := ap.ExtractAction(&file, "bin")
+	assert.Nil(t, exists("./action/x5", "bin/exec.jar"))
+	assert.Nil(t, err)
+	os.Setenv("OW_SAVE_JAR", "")
+}
+
+func TestExtractAction_extract_jar(t *testing.T) {
+	os.Setenv("OW_SAVE_JAR", "")
+	log, _ := ioutil.TempFile("", "log")
+	assert.Nil(t, os.RemoveAll("./action/x6"))
+	ap := NewActionProxy("./action/x6", "", log, log)
+	file, _ := ioutil.ReadFile("_test/sample.jar")
+	_, err := ap.ExtractAction(&file, "bin")
+	assert.Nil(t, exists("./action/x6", "bin/META-INF/MANIFEST.MF"))
+	assert.Nil(t, err)
+}
+
 
 func TestHighestDir(t *testing.T) {
 	assert.Equal(t, highestDir("./_test"), 0)

--- a/openwhisk/filetype.go
+++ b/openwhisk/filetype.go
@@ -45,6 +45,7 @@ func IsBangPath(buf []byte) bool {
 
 // IsExecutable check if it is an executable, according the current runtime
 func IsExecutable(buf []byte, runtime string) bool {
+	Debug("checking executable for %s", runtime)
 	switch runtime {
 	case "darwin":
 		return IsMach64(buf) || IsBangPath(buf)

--- a/openwhisk/initHandler.go
+++ b/openwhisk/initHandler.go
@@ -51,7 +51,8 @@ func sendOK(w http.ResponseWriter) {
 
 func (ap *ActionProxy) initHandler(w http.ResponseWriter, r *http.Request) {
 
-	if ap.initialized {
+	// you can do muliple initializations when debugging
+	if ap.initialized && !Debugging {
 		msg := "Cannot initialize the action more than once."
 		sendError(w, http.StatusForbidden, msg)
 		log.Println(msg)

--- a/openwhisk/runHandler.go
+++ b/openwhisk/runHandler.go
@@ -35,7 +35,7 @@ func sendError(w http.ResponseWriter, code int, cause string) {
 	b, err := json.Marshal(errResponse)
 	if err != nil {
 		b = []byte("error marshalling error response")
-		fmt.Println(b, err)
+		Debug(err.Error())
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)

--- a/openwhisk/util_test.go
+++ b/openwhisk/util_test.go
@@ -170,8 +170,8 @@ func removeLineNr(out string) string {
 	return re.ReplaceAllString(out, "::")
 }
 func TestMain(m *testing.M) {
-	var Debug = false // enable debug of tests
-	if !Debug {
+	Debugging = false // enable debug of tests
+	if !Debugging {
 		// silence those annoying tests
 		log.SetOutput(ioutil.Discard)
 		// build support files

--- a/openwhisk/version.go
+++ b/openwhisk/version.go
@@ -17,4 +17,4 @@
 package openwhisk
 
 // Version number - internal
-var Version = "2"
+var Version = "2.1"

--- a/openwhisk/zip_test.go
+++ b/openwhisk/zip_test.go
@@ -21,12 +21,12 @@ import (
 	"os"
 )
 
-func Example() {
+func Example_zip() {
 	os.RemoveAll("./action/unzip")
 	os.Mkdir("./action/unzip", 0755)
 	buf, err := Zip("_test/pysample")
 	fmt.Println(err)
-	err = Unzip(buf, "./action/unzip")
+	err = UnzipOrSaveJar(buf, "./action/unzip", "./action/unzip/exec.jar")
 	sys("_test/find.sh", "./action/unzip")
 	fmt.Println(err)
 	// Output:
@@ -38,5 +38,19 @@ func Example() {
 	// ./action/unzip/lib/action/__init__.py
 	// ./action/unzip/lib/action/main.py
 	// ./action/unzip/lib/exec.py
+	// <nil>
+}
+func Example_jar() {
+	os.RemoveAll("./action/unzip")
+	os.Mkdir("./action/unzip", 0755)
+	buf, err := Zip("_test/jar")
+	fmt.Println(err)
+	err = UnzipOrSaveJar(buf, "./action/unzip", "./action/unzip/exec.jar")
+	sys("_test/find.sh", "./action/unzip")
+	fmt.Println(err)
+	// Output:
+	// <nil>
+	// ./action/unzip
+	// ./action/unzip/exec.jar
 	// <nil>
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,6 +19,7 @@ include 'tests'
 
 include 'actionloop'
 include 'golang1.11'
+include 'golang1.12'
 
 rootProject.name = 'runtime-golang'
 

--- a/tests/src/test/scala/runtime/actionContainers/ActionLoopBasicGo12Tests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/ActionLoopBasicGo12Tests.scala
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package runtime.actionContainers
+
+import actionContainers.ActionContainer.withContainer
+import actionContainers.{ActionContainer, BasicActionRunnerTests}
+import common.WskActorSystem
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ActionLoopBasicGo12Tests
+    extends BasicActionRunnerTests
+    with WskActorSystem {
+
+  val goCompiler = "actionloop-golang-v1.12"
+  val image = goCompiler
+
+  override def withActionContainer(env: Map[String, String] = Map.empty)(
+      code: ActionContainer => Unit) = {
+    withContainer(image, env)(code)
+  }
+
+  def withActionLoopContainer(code: ActionContainer => Unit) =
+    withContainer(image)(code)
+
+  behavior of image
+
+  override val testNoSourceOrExec = TestConfig("")
+
+  override val testNotReturningJson = TestConfig(
+    """
+      |package main
+      |import (
+      |	"bufio"
+      |	"fmt"
+      |	"os"
+      |)
+      |func main() {
+      |	reader := bufio.NewReader(os.Stdin)
+      |	out := os.NewFile(3, "pipe")
+      |	defer out.Close()
+      |	reader.ReadBytes('\n')
+      |	fmt.Fprintln(out, "\"a string but not a map\"")
+      |	reader.ReadBytes('\n')
+      |}
+    """.stripMargin)
+
+  override val testEcho = TestConfig(
+    """|package main
+       |import "fmt"
+       |import "log"
+       |func Main(args map[string]interface{}) map[string]interface{} {
+       | fmt.Println("hello stdout")
+       | log.Println("hello stderr")
+       | return args
+       |}
+    """.stripMargin)
+
+  override val testUnicode = TestConfig(
+    """|package main
+       |import "fmt"
+       |func Main(args map[string]interface{}) map[string]interface{} {
+       |	delimiter := args["delimiter"].(string)
+       |	str := delimiter + " ☃ " + delimiter
+       |  fmt.Println(str)
+       |	res := make(map[string]interface{})
+       |	res["winter"] = str
+       |	return res
+       |}
+       """.stripMargin)
+
+  override val testEnv = TestConfig(
+    """
+      |package main
+      |import "os"
+      |func Main(args map[string]interface{}) map[string]interface{} {
+      |	res := make(map[string]interface{})
+      |	res["api_host"] = os.Getenv("__OW_API_HOST")
+      |	res["api_key"] = os.Getenv("__OW_API_KEY")
+      |	res["namespace"] = os.Getenv("__OW_NAMESPACE")
+      |	res["action_name"] = os.Getenv("__OW_ACTION_NAME")
+      |	res["activation_id"] = os.Getenv("__OW_ACTIVATION_ID")
+      |	res["deadline"] = os.Getenv("__OW_DEADLINE")
+      |	return res
+      |}
+    """.stripMargin)
+
+  override val testInitCannotBeCalledMoreThanOnce = TestConfig(
+    """|package main
+       |func Main(args map[string]interface{}) map[string]interface{} {
+       | return args
+       |}
+    """.stripMargin)
+
+  override val testEntryPointOtherThanMain = TestConfig(
+    """|package main
+       |func Niam(args map[string]interface{}) map[string]interface{} {
+       | return args
+       |}
+    """.stripMargin,
+    main = "niam"
+  )
+
+  override val testLargeInput = TestConfig(
+    """|package main
+       |func Main(args map[string]interface{}) map[string]interface{} {
+       | return args
+       |}
+    """.stripMargin)
+}

--- a/tests/src/test/scala/runtime/actionContainers/ActionLoopGo12ContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/ActionLoopGo12ContainerTests.scala
@@ -15,8 +15,129 @@
  * limitations under the License.
  */
 
- @RunWith(classOf[JUnitRunner])
-class ActionLoopGo12ContainerTests extends ActionLoopGoContainerTests {
-     val goCompiler = "actionloop-golang-v1.12"
-     val image = goCompiler
+package runtime.actionContainers
+
+//import java.util.concurrent.TimeoutException
+import actionContainers.ActionContainer.withContainer
+import actionContainers.{ActionContainer, ActionProxyContainerTestUtils}
+import common.WskActorSystem
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+//import spray.json.JsNumber
+//import spray.json.JsBoolean
+import spray.json.{JsObject, JsString}
+
+@RunWith(classOf[JUnitRunner])
+class ActionLoopGo12ContainerTests
+    extends ActionProxyContainerTestUtils
+    with WskActorSystem {
+
+  import GoResourceHelpers._
+
+  val goCompiler = "actionloop-golang-v1.12"
+  val image = goCompiler
+
+  def withActionLoopContainer(code: ActionContainer => Unit) =
+    withContainer(image)(code)
+
+  behavior of image
+
+  def helloGo(main: String, pkg: String = "main") = {
+    val func = main.capitalize
+    s"""|package ${pkg}
+        |
+        |import "fmt"
+        |
+        |func ${func}(obj map[string]interface{}) map[string]interface{} {
+        |	 name, ok := obj["name"].(string)
+        |	 if !ok {
+        |	  	name = "Stranger"
+        |	 }
+        |	 fmt.Printf("name=%s\\n", name)
+        |  msg := make(map[string]interface{})
+        |	 msg["${pkg}-${main}"] = "Hello, " + name + "!"
+        |	 return msg
+        |}
+        |""".stripMargin
+  }
+
+   def helloSrc(main: String) = Seq(
+    Seq(s"${main}.go") -> helloGo(main)
+  )
+
+  def helloMsg(name: String = "Demo") =
+    runPayload(JsObject("name" -> JsString(name)))
+
+  def okMsg(key: String, value: String) =
+    200 -> Some(JsObject(key -> JsString(value)))
+
+  it should "run sample with init that does nothing" in {
+    val (out, err) = withActionLoopContainer { c =>
+      c.init(JsObject())._1 should be(403)
+      c.run(JsObject())._1 should be(500)
+    }
+  }
+
+  it should "accept a binary main" in {
+    val exe = ExeBuilder.mkBase64Zip(goCompiler, helloSrc("main"), "main")
+
+    withActionLoopContainer { c =>
+      c.init(initPayload(exe))._1 shouldBe (200)
+      c.run(helloMsg()) should be(okMsg("main-main", "Hello, Demo!"))
+    }
+  }
+
+
+  it should "accept a src main action " in {
+    var src = ExeBuilder.mkBase64Src(helloSrc("main"))
+    withActionLoopContainer { c =>
+      c.init(initPayload(src))._1 shouldBe (200)
+      c.run(helloMsg()) should be(okMsg("main-main", "Hello, Demo!"))
+    }
+  }
+
+  it should "accept a src not-main action " in {
+    var src = ExeBuilder.mkBase64Src(helloSrc("hello"))
+    withActionLoopContainer { c =>
+      c.init(initPayload(src, "hello"))._1 shouldBe (200)
+      c.run(helloMsg()) should be(okMsg("main-hello", "Hello, Demo!"))
+    }
+  }
+
+  it should "accept a zipped src main action" in {
+    var src = ExeBuilder.mkBase64SrcZip(helloSrc("main"))
+    withActionLoopContainer { c =>
+      c.init(initPayload(src))._1 shouldBe (200)
+      c.run(helloMsg()) should be(okMsg("main-main", "Hello, Demo!"))
+    }
+  }
+
+  it should "accept a zipped src not-main action" in {
+    var src = ExeBuilder.mkBase64SrcZip(helloSrc("hello"))
+    withActionLoopContainer { c =>
+      c.init(initPayload(src, "hello"))._1 shouldBe (200)
+      c.run(helloMsg()) should be(okMsg("main-hello", "Hello, Demo!"))
+    }
+  }
+
+  it should "deploy a zip main src with subdir" in {
+    var src = ExeBuilder.mkBase64SrcZip(
+      Seq(
+        Seq("hello", "hello.go") -> helloGo("Hello", "hello"),
+        Seq("main.go") ->
+          """
+          |package main
+          |import "hello"
+          |func Main(args map[string]interface{})map[string]interface{} {
+          | return hello.Hello(args)
+          |}
+        """.stripMargin
+      )
+    )
+    withActionLoopContainer { c =>
+      c.init(initPayload(src))._1 shouldBe (200)
+      c.run(helloMsg()) should be(okMsg("hello-Hello", "Hello, Demo!"))
+    }
+  }
 }

--- a/tests/src/test/scala/runtime/actionContainers/ActionLoopGo12ContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/ActionLoopGo12ContainerTests.scala
@@ -15,25 +15,8 @@
  * limitations under the License.
  */
 
-ext.dockerImageName = 'actionloop-v2'
-apply from: '../gradle/docker.gradle'
-
-distDocker.dependsOn 'staticBuildProxy'
-distDocker.finalizedBy('cleanup')
-
-task staticBuildProxy(type: Exec) {
-	environment CGO_ENABLED: "0"
-	environment GOOS: "linux"
-	environment GOARCH: "amd64"
-
-	commandLine 'go', 'build',
-		'-o',  'proxy', '-a',
-		'-ldflags', '-extldflags "-static"',
-		'../main/proxy.go'
-}
-
-task cleanup(type: Delete) {
-    delete 'proxy'
-    delete 'gobuild.py'
-    delete 'gobuild.py.launcher.go'
+ @RunWith(classOf[JUnitRunner])
+class ActionLoopGo12ContainerTests extends ActionLoopGoContainerTests {
+     val goCompiler = "actionloop-golang-v1.12"
+     val image = goCompiler
 }

--- a/tests/src/test/scala/runtime/actionContainers/ActionLoopGoContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/ActionLoopGoContainerTests.scala
@@ -62,14 +62,14 @@ class ActionLoopGoContainerTests
         |""".stripMargin
   }
 
-  private def helloSrc(main: String) = Seq(
+   def helloSrc(main: String) = Seq(
     Seq(s"${main}.go") -> helloGo(main)
   )
 
-  private def helloMsg(name: String = "Demo") =
+  def helloMsg(name: String = "Demo") =
     runPayload(JsObject("name" -> JsString(name)))
 
-  private def okMsg(key: String, value: String) =
+  def okMsg(key: String, value: String) =
     200 -> Some(JsObject(key -> JsString(value)))
 
   it should "run sample with init that does nothing" in {

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -41,7 +41,7 @@ echo "vcap.services.file=" >> whisk.properties
 # Build/Compile go
 cd $ROOTDIR
 # compile without testing as we need docker images first
-TERM=dumb ./gradlew build -x test
+TERM=dumb ./gradlew goBuild -x test
 # ok now you can build docker images using the compiled proxy
 TERM=dumb ./gradlew distDocker
 

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -40,8 +40,6 @@ echo "vcap.services.file=" >> whisk.properties
 
 # Build/Compile go
 cd $ROOTDIR
-# compile without testing as we need docker images first
-TERM=dumb ./gradlew goBuild -x test
-# ok now you can build docker images using the compiled proxy
+# just build docker images - they compile the proxy
 TERM=dumb ./gradlew distDocker
 

--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -38,3 +38,5 @@ git clone https://github.com/apache/incubator-openwhisk-utilities.git
 git clone --depth=1 https://github.com/apache/incubator-openwhisk.git openwhisk
 cd openwhisk
 ./tools/travis/setup.sh
+go get github.com/sirupsen/logrus
+go get github.com/stretchr/testify/assert

--- a/tools/travis/test.sh
+++ b/tools/travis/test.sh
@@ -26,7 +26,8 @@ WHISKDIR="$ROOTDIR/../openwhisk"
 
 export OPENWHISK_HOME=$WHISKDIR
 cd ${ROOTDIR}
-TERM=dumb ./gradlew :tests:test
 go version
+pushd openwhisk
+go test -v
+popd
 TERM=dumb ./gradlew test --info
-

--- a/tools/travis/test.sh
+++ b/tools/travis/test.sh
@@ -26,8 +26,8 @@ WHISKDIR="$ROOTDIR/../openwhisk"
 
 export OPENWHISK_HOME=$WHISKDIR
 cd ${ROOTDIR}
-go version
 pushd openwhisk
+go version
 go test -v
 popd
 TERM=dumb ./gradlew test --info


### PR DESCRIPTION
- Support for Go 1.12.4
- Support for jar not expanded for Java when set OW_SAVE_JAR
- You can initalize multiple times when debugging
- Removed gogradle plugin, now building directly with go
